### PR TITLE
Add vendor prefixes for old safari and flexbox.

### DIFF
--- a/scss/_layout.scss
+++ b/scss/_layout.scss
@@ -17,6 +17,8 @@ h1, h2, h3, h4, h5, h6 {
   position: relative;
   display: -webkit-flex;
   -webkit-flex-direction: column;
+  display: -webkit-box-flex;
+  -webkit-box-direction: column;
   color: $white;
 }
 


### PR DESCRIPTION
- add -webkit-box-flex
- We need to get @Jasminpatel1 to test this on her iPad before we can close the issue.

Related #120